### PR TITLE
Crafting Tweaks and Fixes

### DIFF
--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -23,7 +23,7 @@
 /datum/crafting_recipe/roguetown/breakdowncloth
 	name = "unwind cloth"
 	result = /obj/item/natural/fibers //inefficient, will need two cloth to make back what was broken down for another cloth
-	reqs = list(obj/item/natural/cloth = 1)
+	reqs = list(/obj/item/natural/cloth = 1)
 	skillcraft = null
 	verbage_simple = "pick apart"
 	verbage = "picks apart"

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -20,10 +20,20 @@
 	verbage = "sews"
 	craftdiff = 0
 
+/datum/crafting_recipe/roguetown/breakdowncloth
+	name = "unwind cloth"
+	result = /obj/item/natural/fibers //inefficient, will need two cloth to make back what was broken down for another cloth
+	reqs = list(obj/item/natural/cloth = 1)
+	skillcraft = null
+	verbage_simple = "pick apart"
+	verbage = "picks apart"
+	craftdiff = 0
+
 /datum/crafting_recipe/roguetown/clothbelt
 	name = "cloth belt"
 	result = /obj/item/storage/belt/rogue/leather/cloth
 	reqs = list(/obj/item/natural/cloth = 1)
+	skillcraft = null //CC edit: No crafting skill should be gained for tying cloth/rope in a knot
 	craftdiff = 0
 	verbage_simple = "tie"
 	verbage = "ties"
@@ -32,6 +42,7 @@
 	name = "untie cloth belt"
 	result = /obj/item/natural/cloth
 	reqs = list(/obj/item/storage/belt/rogue/leather/cloth = 1)
+	skillcraft = null
 	craftdiff = 0
 	verbage_simple = "untie"
 	verbage = "unties"
@@ -40,6 +51,7 @@
 	name = "rope belt"
 	result = /obj/item/storage/belt/rogue/leather/rope
 	reqs = list(/obj/item/rope = 1)
+	skillcraft = null
 	craftdiff = 0
 	verbage_simple = "tie"
 	verbage = "ties"
@@ -48,6 +60,7 @@
 	name = "untie rope belt"
 	result = /obj/item/rope
 	reqs = list(/obj/item/storage/belt/rogue/leather/rope = 1)
+	skillcraft = null
 	craftdiff = 0
 	verbage_simple = "untie"
 	verbage = "unties"

--- a/code/modules/roguetown/roguecrafting/items.dm
+++ b/code/modules/roguetown/roguecrafting/items.dm
@@ -139,6 +139,7 @@
 	name = "wood club"
 	result = /obj/item/rogueweapon/mace/woodclub/crafted
 	reqs = list(/obj/item/grown/log/tree/small = 1)
+	craftdiff = 0
 
 /datum/crafting_recipe/roguetown/billhook
 	name = "improvised billhook"

--- a/code/modules/roguetown/roguejobs/miner/tools.dm
+++ b/code/modules/roguetown/roguejobs/miner/tools.dm
@@ -61,4 +61,4 @@
 	possible_item_intents = list(/datum/intent/pick)
 	gripped_intents = list(/datum/intent/pick)
 	max_integrity = 250
-	smeltresult = /obj/item/ingot/steel
+	smeltresult = /obj/item/natural/stone


### PR DESCRIPTION
## About The Pull Request

- Changes the smelt result for a stone pickaxe from a steel ingot to a stone
- Rebalances the cloth/rope belt recipes and untie recipes to have no skill associated with them to prevent infinite skill grinding
- Added a reverse cloth recipe to break down cloth, only for half the returns
- Gave the wood club recipe 0 crafting skill requirement
