### PR TITLE
port my beheaded player hearing fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -544,5 +544,5 @@
 /mob/living/carbon/can_hear()
 	. = FALSE
 	var/obj/item/organ/ears/ears = getorganslot(ORGAN_SLOT_EARS)
-	if(istype(ears) && !ears.deaf)
+	if((istype(ears) && !ears.deaf) || (src.stat == DEAD)) // 2nd check so you can hear messages when beheaded
 		. = TRUE


### PR DESCRIPTION
## About The Pull Request
if you are beheaded (and dead) but still in your body, you can't hear like you're supposed to.
this fixes that. if you'd normally be deaf but you're also dead, you can hear