### PR TITLE
Templar Fix 2

### DIFF
--- a/code/controllers/subsystem/rogue/devotion.dm
+++ b/code/controllers/subsystem/rogue/devotion.dm
@@ -123,7 +123,7 @@
 
 	var/list/spelllist = list(/obj/effect/proc_holder/spell/targeted/touch/orison, patron.t0)
 	if(istype(patron,/datum/patron/divine))
-		spelllist += /obj/effect/proc_holder/spell/targeted/abrogation
+		spelllist += /obj/effect/proc_holder/spell/targeted/churn
 	for(var/spell_type in spelllist)
 		if(!spell_type || H.mind.has_spell(spell_type))
 			continue

--- a/code/datums/gods/patrons/divine_pantheon.dm
+++ b/code/datums/gods/patrons/divine_pantheon.dm
@@ -112,11 +112,11 @@
 	desc = "Goddess that blessed many a saint with healing hands, Pestra taught man the arts of medicine and its benefits."
 	worshippers = "The Sick, Phyicians, Apothecaries"
 	mob_traits = list(TRAIT_EMPATH, TRAIT_ROT_EATER)
-	t0 = list(/obj/effect/proc_holder/spell/invoked/diagnose)
-	t1 = list(/obj/effect/proc_holder/spell/invoked/lesser_heal)
-	t2 = list(/obj/effect/proc_holder/spell/invoked/heal)
-	t3 = list(/obj/effect/proc_holder/spell/invoked/attach_bodypart)
-	t4 = list(/obj/effect/proc_holder/spell/invoked/cure_rot)
+	t0 = /obj/effect/proc_holder/spell/invoked/diagnose
+	t1 = /obj/effect/proc_holder/spell/invoked/lesser_heal
+	t2 = /obj/effect/proc_holder/spell/invoked/heal
+	t3 = /obj/effect/proc_holder/spell/invoked/attach_bodypart
+	t4 = /obj/effect/proc_holder/spell/invoked/cure_rot
 	confess_lines = list(
 		"PESTRA SOOTHES ALL ILLS!",
 		"DECAY IS A CONTINUATION OF LIFE!",

--- a/code/modules/jobs/job_types/roguetown/church/templar.dm
+++ b/code/modules/jobs/job_types/roguetown/church/templar.dm
@@ -175,13 +175,13 @@
 	var/weapon_choice = input(H,"Choose your weapon.", "TAKE UP ARMS") as anything in weapons
 	switch(weapon_choice)
 		if("Bastard Sword")
-			H.put_in_hands(new /obj/item/rogueweapon/sword/long, TRUE)
+			r_hand = /obj/item/rogueweapon/sword/long
 			H.mind.adjust_skillrank(/datum/skill/combat/swords, 1, TRUE)
 		if("Flail")
-			H.put_in_hands(new /obj/item/rogueweapon/flail, TRUE)
+			r_hand = /obj/item/rogueweapon/flail
 			H.mind.adjust_skillrank(/datum/skill/combat/whipsflails, 1, TRUE)
 		if("Mace")
-			H.put_in_hands(new /obj/item/rogueweapon/mace, TRUE)
+			r_hand = /obj/item/rogueweapon/mace
 			H.mind.adjust_skillrank(/datum/skill/combat/maces, 1, TRUE)
 
 


### PR DESCRIPTION
Okay, a few more fixes for templar -
- Corrects paladins and templars getting Aborgation instead of churn as their anti-undead spell of choice.
- Fixed the inconsistent weapon spawn for templars. This might cause weapons to spawn on the ground, but it's better then them not spawning at all
- Fixes an issue with the Pestran spell list, whoops this one was from me

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
