### PR TITLE
Gun bug fixes

### DIFF
--- a/code/game/objects/items/rogueweapons/ranged/gunpowder/ammo.dm
+++ b/code/game/objects/items/rogueweapons/ranged/gunpowder/ammo.dm
@@ -31,6 +31,30 @@
 	woundclass = BCLASS_STAB
 	flag = "bullet"
 
+/obj/projectile/bullet/reusable/runelock/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	
+	var/mob/living/L = firer
+	if(!L || !L.mind) return
+
+	var/skill_multiplier = 0
+
+	if(isliving(target)) // If the target theyre shooting at is a mob/living
+		var/mob/living/T = target
+		if(T.stat != DEAD) // If theyre alive
+			skill_multiplier = 4
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/firearms, SKILL_LEVEL_EXPERT))
+		L.mind.add_sleep_experience(/datum/skill/combat/firearms, L.STAINT * skill_multiplier)
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/M = target
+		var/list/screams = list("painscream", "paincrit")
+		var/check = rand(1, 20)
+		if(isliving(target))
+			if(check > M.STACON)
+				M.emote(screams)
+				M.Knockdown(rand(15,30))
+				M.Immobilize(rand(30,60))
+
 /**
  * Generic ammo used by handgonnes and arquebuses
  */
@@ -50,19 +74,6 @@
 	armor_penetration = 75
 	speed = 0.1
 
-/obj/projectile/bullet/rogue/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(istype(target, /mob/living/carbon/human))
-		var/mob/living/carbon/human/M = target
-		var/list/screams = list("painscream", "paincrit")
-		var/check = rand(1, 20)
-		if(isliving(target))
-			if(check > M.STACON)
-				M.emote(screams)
-				M.Knockdown(rand(15,30))
-				M.Immobilize(rand(30,60))
-
-
 /obj/item/ammo_casing/caseless/lead
 	name = "lead sphere"
 	desc = "A small lead sphere. This should go well with gunpowder."
@@ -72,3 +83,27 @@
 	icon_state = "musketball"
 	dropshrink = 0.5
 	max_integrity = 0.1
+
+/obj/projectile/bullet/lead/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	
+	var/mob/living/L = firer
+	if(!L || !L.mind) return
+
+	var/skill_multiplier = 0
+
+	if(isliving(target)) // If the target theyre shooting at is a mob/living
+		var/mob/living/T = target
+		if(T.stat != DEAD) // If theyre alive
+			skill_multiplier = 4
+	if(skill_multiplier && can_train_combat_skill(L, /datum/skill/combat/firearms, SKILL_LEVEL_EXPERT))
+		L.mind.add_sleep_experience(/datum/skill/combat/firearms, L.STAINT * skill_multiplier)
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/M = target
+		var/list/screams = list("painscream", "paincrit")
+		var/check = rand(1, 20)
+		if(isliving(target))
+			if(check > M.STACON)
+				M.emote(screams)
+				M.Knockdown(rand(15,30))
+				M.Immobilize(rand(30,60))

--- a/code/game/objects/items/rogueweapons/ranged/gunpowder/arquebus.dm
+++ b/code/game/objects/items/rogueweapons/ranged/gunpowder/arquebus.dm
@@ -37,7 +37,7 @@
 	//pickup_sound = 'sound/sheath_sounds/draw_from_holster.ogg'
 	//sheathe_sound = 'sound/sheath_sounds/put_back_to_holster.ogg'
 	var/spread_num = 10
-	var/damfactor = 2
+	var/damfactor = 2.5
 	var/reloaded = FALSE
 	var/load_time = 50
 	var/gunpowder = FALSE

--- a/code/game/objects/items/rogueweapons/ranged/gunpowder/handgonne.dm
+++ b/code/game/objects/items/rogueweapons/ranged/gunpowder/handgonne.dm
@@ -173,6 +173,9 @@
 			spread = 150 - (150 * (user.client.chargedprog / 100))
 	else
 		spread = 0
+	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
+		var/obj/projectile/BB = CB.BB
+		BB.damage = BB.damage * damfactor
 	gunpowder = FALSE
 	reloaded = FALSE
 	spark_act()

--- a/code/game/objects/items/rogueweapons/ranged/gunpowder/pistol.dm
+++ b/code/game/objects/items/rogueweapons/ranged/gunpowder/pistol.dm
@@ -160,6 +160,9 @@
 			spread = 150 - (150 * (user.client.chargedprog / 100))
 	else
 		spread = 0
+	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
+		var/obj/projectile/BB = CB.BB
+		BB.damage = BB.damage * damfactor
 	gunpowder = FALSE
 	reloaded = FALSE
 	spark_act()

--- a/code/game/objects/items/rogueweapons/ranged/gunpowder/runelock.dm
+++ b/code/game/objects/items/rogueweapons/ranged/gunpowder/runelock.dm
@@ -26,7 +26,7 @@
 	/// Reload time, in SECONDS
 	var/reload_time = 10
 	//weapon_embed_chance = 100 //this was here to make a weaker version of the gun, didn't do it, still keeping this here to be used
-	var/damfactor = 5
+	var/damfactor = 2
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/runelock/getonmobprop(tag)
 	. = ..()
@@ -81,6 +81,9 @@
 		explosion(src, light_impact_range = 2, heavy_impact_range = 1, smoke = TRUE, soundin = 'sound/misc/explode/bomb.ogg')
 		qdel(src)
 		return
+	for(var/obj/item/ammo_casing/CB in get_ammo_list(FALSE, TRUE))
+		var/obj/projectile/BB = CB.BB
+		BB.damage = BB.damage * damfactor
 	cocked = FALSE
 	icon_state = initial(icon_state)
 	var/dir = get_dir(src, target)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

- Corrects the missing damage factor multiplier in ranged attack damage
- Corrects the on_hit proc for ammo, allowing attacks to knock people down on a random chance
- Adds in EXP gain for shooting living targets with guns
- Reduced the damage factor on the runelock from 5x to 2x. The runelock's damage is only 80, but it's significantly faster to load then other firearms. (No gunpowder or ramrod stage to loading)

## Why It's Good For The Game

Guns are pretty useless, and this corrects several intended features to make them work - and guns much less useless.
