### PR TITLE
Simple Mob Skely gain undead, and churn adjust

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
+++ b/code/modules/mob/living/simple_animal/hostile/simple_skeleton.dm
@@ -6,7 +6,7 @@
 	icon_living = "skeleton"
 	icon_dead = "skeleton_dead"
 	gender = MALE
-	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID
+	mob_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_UNDEAD
 	robust_searching = 1
 	turns_per_move = 1
 	move_to_delay = 3

--- a/code/modules/spells/roguetown/acolyte/necra.dm
+++ b/code/modules/spells/roguetown/acolyte/necra.dm
@@ -55,8 +55,8 @@
 	for(var/mob/living/L in targets)
 		var/isvampire = FALSE
 		var/iszombie = FALSE
-		if(L.stat == DEAD)
-			continue
+//		if(L.stat == DEAD) //I do not know exactly why this check is here, but this prevents simplemob undead from being churned. Begon, Caustic change
+//			continue
 		if(L.mind)
 			var/datum/antagonist/vampirelord/lesser/V = L.mind.has_antag_datum(/datum/antagonist/vampirelord/lesser)
 			if(V)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Simple mob Skeleton now has MOB_UNDEAD so its correctly declared as undead
Churn now does not check for of someone is living, relying more on MOB_UNDEAD, this permits targetting simple mobs. This can easily be undone once simple mob skelies are removed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
churn is supposed to hit undead, skeletons are supposed to be undead
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
