### PR TITLE
Vendor Exploit Fix

### DIFF
--- a/code/modules/roguetown/roguemachine/vendor.dm
+++ b/code/modules/roguetown/roguemachine/vendor.dm
@@ -135,7 +135,7 @@
 			if(newprice)
 				if(findtext(num2text(newprice), "."))
 					return attack_hand(usr)
-				held_items[O]["PRICE"] = newprice
+				held_items[O]["PRICE"] = CLAMP(newprice, 0 , 9999)
 	return attack_hand(usr)
 
 /obj/structure/roguemachine/vendor/attack_hand(mob/living/user)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Makes it so there's a maximum and minimum price on the vendors, so you can't make infinite money by putting in a negative value. Tested Locally.


## Why It's Good For The Game

Removes an infinite money glitch.