### PR TITLE
Update roguetown.dme to enable my .DMs

### DIFF
--- a/roguetown.dme
+++ b/roguetown.dme
@@ -3660,6 +3660,7 @@
 #include "modular_causticcove\code\datums\status_effects\rogue\causticbuff.dm"
 #include "modular_causticcove\code\modules\roguetown\roguejobs\alchemist\reagent.dm"
 #include "modular_causticcove\code\modules\roguetown\roguecrafting\alchemy.dm"
+#include "modular_causticcove\code\modules\roguetown\roguecrafting\weaving.dm"
 #include "modular_causticcove\code\modules\roguetown\roguejobs\alchemist\containers.dm"
 #include "modular_causticcove\code\game\area\objects\items\rogueitems\natural\animals.dm"
 #include "modular_causticcove\code\modules\mob\living\simple_animal\rogue\eldritch\beast_mother.dm"
@@ -3668,4 +3669,5 @@
 #include "modular_causticcove\code\datums\status_effects\rogue\causticdebuff.dm"
 #include "modular_hearthstone\code\modules\spells\roguetown\spells5e\cantrips5e.dm"
 #include "modular_hearthstone\code\modules\spells\roguetown\spells5e\spellscrolls.dm"
+#include "modular_causticcove\code\modules\clothing\rogueclothes\armor.dm"
 // END_INCLUDE


### PR DESCRIPTION
I'm dum and don't know how coding these things works, so I have now included the two .dm files from my previous PR to actually be enabled in the game.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I'm big stupid, and forgot to add the lines to the .dme file that enabled the new weaving.dm and armor.dm that I added for the two new pieces of armor.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
This just enabled the egyptian robe and headdresses, and allows them to be crafted with silk, along with adding the barrel armor but that's not craftable. I just forgot to include these in my initial PR because I'm big dumb dumb and didn't realize I had to enable them via code.